### PR TITLE
Add Afterburner Indication window

### DIFF
--- a/bms-burner/AfterburnerIndicator.cs
+++ b/bms-burner/AfterburnerIndicator.cs
@@ -1,0 +1,129 @@
+﻿using SharpDX.DirectInput;
+using System;
+using System.IO;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using System.Windows.Forms;
+using System.Drawing;
+using System.Runtime.InteropServices;
+
+namespace bms_burner
+{
+    public class AfterburnerIndicator
+    {
+        public bool hasRun = false;
+        protected Joystick throttle;
+        private JoystickState thrState = new JoystickState();
+        protected int aB;
+        protected Point loc;
+        public ScreenLocation scrLoc;
+        public int width;
+        public int height;
+        public bool isEnabled;
+        const int JOYSTICK_POLL_PERIOD = 16;
+        const int BMS_POLL_PERIOD = 1000;
+        Form f;
+        Timer throttlePoller;
+
+        private Func<JoystickState, int> AxisDelegate;
+
+        public AfterburnerIndicator()
+        {
+            scrLoc = ScreenLocation.Top_Left;
+            width = 80;
+            height = 80;
+            isEnabled = false;
+        }
+
+        public void Execute(Func<JoystickState, int> refFunc, int aBLoc, Joystick throttle)
+        {
+            this.throttle = throttle;
+            this.AxisDelegate = refFunc;
+            this.aB = aBLoc;
+            f = new Form();
+            f.BackColor = Color.Blue;
+            f.FormBorderStyle = FormBorderStyle.None;
+            int screenWidth = Screen.PrimaryScreen.Bounds.Width;
+            int screenHeight = Screen.PrimaryScreen.Bounds.Height;
+            f.Size = new Size(width, height);
+            f.TopMost = true;
+            f.StartPosition = FormStartPosition.Manual;
+            Point p = new Point(0, 0);
+            switch (scrLoc)
+            {
+                case ScreenLocation.Top_Left:
+                    break;
+                case ScreenLocation.Top_Right:
+                    p = new Point(screenWidth - width, 0);
+                    break;
+                case ScreenLocation.Bottom_Left:
+                    p = new Point(0, screenHeight - height);
+                    break;
+                case ScreenLocation.Bottom_Right:
+                    p = new Point(screenWidth - width, screenHeight - height);
+                    break;
+            }
+            f.Location = p;
+            f.Opacity = 0;
+
+            throttlePoller = new Timer();
+            throttlePoller.Interval = JOYSTICK_POLL_PERIOD;
+            throttlePoller.Tick += new EventHandler(onThrottlePoll);
+
+            f.ShowDialog();
+        }
+        public void onBMSPoll(bool isBMS3d)
+        {
+            if (isBMS3d && !hasRun)
+            {
+                f.Opacity = 1;
+                throttlePoller.Start();
+                hasRun = true;
+            }
+            if (!isBMS3d && hasRun)
+            {
+                f.Close();
+                throttlePoller.Stop();
+            }
+        }
+        protected void onThrottlePoll(object sender, EventArgs e)
+        {
+            throttle.GetCurrentState(ref thrState);
+            int input = AxisDelegate(thrState);
+            //reverse the input
+            input = MainWindow.MAXIN - input;
+            if (input > aB)
+                f.BackColor = Color.Red;
+            else
+                f.BackColor = Color.Blue;
+        }
+
+        public String getScreenLocation()
+        {
+            switch (scrLoc)
+            {
+                case ScreenLocation.Top_Left:
+                    return "Top Left";
+                case ScreenLocation.Top_Right:
+                    return "Top Right";
+                case ScreenLocation.Bottom_Left:
+                    return "Bottom Left";
+                case ScreenLocation.Bottom_Right:
+                    return "Bottom Right";
+            }
+            return "Top Left";                    
+        }
+
+        [DllImport("kernel32.dll", SetLastError = true)]
+        public static extern IntPtr OpenFileMapping(uint dwDesiredAccess,
+            bool bInheritHandle,
+           string lpName);
+
+        [DllImport("kernel32.dll", SetLastError = true)]
+        public static extern IntPtr MapViewOfFile(IntPtr hFileMappingObject, uint
+           dwDesiredAccess, uint dwFileOffsetHigh, uint dwFileOffsetLow,
+           uint dwNumberOfBytesToMap);
+    }
+}

--- a/bms-burner/AfterburnerWindow.Designer.cs
+++ b/bms-burner/AfterburnerWindow.Designer.cs
@@ -1,0 +1,178 @@
+﻿
+namespace bms_burner
+{
+    partial class AfterburnerWindow
+    {
+        /// <summary>
+        /// Required designer variable.
+        /// </summary>
+        private System.ComponentModel.IContainer components = null;
+
+        /// <summary>
+        /// Clean up any resources being used.
+        /// </summary>
+        /// <param name="disposing">true if managed resources should be disposed; otherwise, false.</param>
+        protected override void Dispose(bool disposing)
+        {
+            if (disposing && (components != null))
+            {
+                components.Dispose();
+            }
+            base.Dispose(disposing);
+        }
+
+        #region Windows Form Designer generated code
+
+        /// <summary>
+        /// Required method for Designer support - do not modify
+        /// the contents of this method with the code editor.
+        /// </summary>
+        private void InitializeComponent()
+        {
+            this.label1 = new System.Windows.Forms.Label();
+            this.label2 = new System.Windows.Forms.Label();
+            this.label3 = new System.Windows.Forms.Label();
+            this.label4 = new System.Windows.Forms.Label();
+            this.enabledCheckBox = new System.Windows.Forms.CheckBox();
+            this.comboBox1 = new System.Windows.Forms.ComboBox();
+            this.Save = new System.Windows.Forms.Button();
+            this.widthTextBox = new System.Windows.Forms.NumericUpDown();
+            this.heightTextBox = new System.Windows.Forms.NumericUpDown();
+            ((System.ComponentModel.ISupportInitialize)(this.widthTextBox)).BeginInit();
+            ((System.ComponentModel.ISupportInitialize)(this.heightTextBox)).BeginInit();
+            this.SuspendLayout();
+            // 
+            // label1
+            // 
+            this.label1.AutoSize = true;
+            this.label1.Font = new System.Drawing.Font("Microsoft Sans Serif", 14F);
+            this.label1.Location = new System.Drawing.Point(12, 9);
+            this.label1.Name = "label1";
+            this.label1.Size = new System.Drawing.Size(294, 24);
+            this.label1.TabIndex = 0;
+            this.label1.Text = "Afterburner Window Configuration";
+            this.label1.Click += new System.EventHandler(this.label1_Click);
+            // 
+            // label2
+            // 
+            this.label2.AutoSize = true;
+            this.label2.Font = new System.Drawing.Font("Microsoft Sans Serif", 12F);
+            this.label2.Location = new System.Drawing.Point(13, 43);
+            this.label2.Name = "label2";
+            this.label2.Size = new System.Drawing.Size(136, 20);
+            this.label2.TabIndex = 1;
+            this.label2.Text = "Indicator Location";
+            // 
+            // label3
+            // 
+            this.label3.AutoSize = true;
+            this.label3.Font = new System.Drawing.Font("Microsoft Sans Serif", 12F);
+            this.label3.Location = new System.Drawing.Point(155, 43);
+            this.label3.Name = "label3";
+            this.label3.Size = new System.Drawing.Size(80, 20);
+            this.label3.TabIndex = 2;
+            this.label3.Text = "Width (px)";
+            // 
+            // label4
+            // 
+            this.label4.AutoSize = true;
+            this.label4.Font = new System.Drawing.Font("Microsoft Sans Serif", 12F);
+            this.label4.Location = new System.Drawing.Point(155, 89);
+            this.label4.Name = "label4";
+            this.label4.Size = new System.Drawing.Size(86, 20);
+            this.label4.TabIndex = 3;
+            this.label4.Text = "Height (px)";
+            // 
+            // enabledCheckBox
+            // 
+            this.enabledCheckBox.AutoSize = true;
+            this.enabledCheckBox.Location = new System.Drawing.Point(159, 138);
+            this.enabledCheckBox.Name = "enabledCheckBox";
+            this.enabledCheckBox.Size = new System.Drawing.Size(65, 17);
+            this.enabledCheckBox.TabIndex = 4;
+            this.enabledCheckBox.Text = "Enabled";
+            this.enabledCheckBox.UseVisualStyleBackColor = true;
+            // 
+            // comboBox1
+            // 
+            this.comboBox1.FormattingEnabled = true;
+            this.comboBox1.Items.AddRange(new object[] {
+            "Top Left",
+            "Top Right",
+            "Bottom Left",
+            "Bottom Right"});
+            this.comboBox1.Location = new System.Drawing.Point(17, 65);
+            this.comboBox1.Name = "comboBox1";
+            this.comboBox1.Size = new System.Drawing.Size(121, 21);
+            this.comboBox1.TabIndex = 5;
+            // 
+            // Save
+            // 
+            this.Save.Location = new System.Drawing.Point(262, 138);
+            this.Save.Name = "Save";
+            this.Save.Size = new System.Drawing.Size(44, 22);
+            this.Save.TabIndex = 8;
+            this.Save.Text = "Save";
+            this.Save.UseVisualStyleBackColor = true;
+            this.Save.Click += new System.EventHandler(this.Save_Click);
+            // 
+            // widthTextBox
+            // 
+            this.widthTextBox.Location = new System.Drawing.Point(159, 67);
+            this.widthTextBox.Maximum = new decimal(new int[] {
+            10000,
+            0,
+            0,
+            0});
+            this.widthTextBox.Name = "widthTextBox";
+            this.widthTextBox.Size = new System.Drawing.Size(120, 20);
+            this.widthTextBox.TabIndex = 9;
+            // 
+            // heightTextBox
+            // 
+            this.heightTextBox.Location = new System.Drawing.Point(159, 112);
+            this.heightTextBox.Maximum = new decimal(new int[] {
+            10000,
+            0,
+            0,
+            0});
+            this.heightTextBox.Name = "heightTextBox";
+            this.heightTextBox.Size = new System.Drawing.Size(120, 20);
+            this.heightTextBox.TabIndex = 10;
+            // 
+            // AfterburnerWindow
+            // 
+            this.AutoScaleDimensions = new System.Drawing.SizeF(6F, 13F);
+            this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
+            this.ClientSize = new System.Drawing.Size(324, 177);
+            this.Controls.Add(this.heightTextBox);
+            this.Controls.Add(this.widthTextBox);
+            this.Controls.Add(this.Save);
+            this.Controls.Add(this.comboBox1);
+            this.Controls.Add(this.enabledCheckBox);
+            this.Controls.Add(this.label4);
+            this.Controls.Add(this.label3);
+            this.Controls.Add(this.label2);
+            this.Controls.Add(this.label1);
+            this.Name = "AfterburnerWindow";
+            this.Text = "AfterburnerWindow";
+            ((System.ComponentModel.ISupportInitialize)(this.widthTextBox)).EndInit();
+            ((System.ComponentModel.ISupportInitialize)(this.heightTextBox)).EndInit();
+            this.ResumeLayout(false);
+            this.PerformLayout();
+
+        }
+
+        #endregion
+
+        private System.Windows.Forms.Label label1;
+        private System.Windows.Forms.Label label2;
+        private System.Windows.Forms.Label label3;
+        private System.Windows.Forms.Label label4;
+        private System.Windows.Forms.CheckBox enabledCheckBox;
+        private System.Windows.Forms.ComboBox comboBox1;
+        private System.Windows.Forms.Button Save;
+        private System.Windows.Forms.NumericUpDown widthTextBox;
+        private System.Windows.Forms.NumericUpDown heightTextBox;
+    }
+}

--- a/bms-burner/AfterburnerWindow.cs
+++ b/bms-burner/AfterburnerWindow.cs
@@ -1,0 +1,66 @@
+﻿using System;
+using System.Collections.Generic;
+using System.ComponentModel;
+using System.Data;
+using System.Drawing;
+using System.IO;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using System.Windows.Forms;
+
+namespace bms_burner
+{
+    public partial class AfterburnerWindow : Form
+    {
+        private AfterburnerIndicator ABIndicator;
+
+        static public AfterburnerIndicator ShowAfterburnerWindow(AfterburnerIndicator ABIndicator)
+        {
+            AfterburnerWindow ownWindow = new AfterburnerWindow(ABIndicator);
+            ownWindow.ShowDialog();
+            return ownWindow.ABIndicator;
+        }
+        public AfterburnerWindow(AfterburnerIndicator ABIndicator)
+        {
+            InitializeComponent();
+            this.ABIndicator = ABIndicator;
+            this.enabledCheckBox.Checked = ABIndicator.isEnabled;
+            this.widthTextBox.Text = ABIndicator.width.ToString();
+            this.heightTextBox.Text = ABIndicator.height.ToString();
+            this.comboBox1.SelectedIndex = comboBox1.FindString(ABIndicator.getScreenLocation());
+        }
+
+        private void label1_Click(object sender, EventArgs e)
+        {
+
+        }
+
+        private void Save_Click(object sender, EventArgs e)
+        {
+            ABIndicator.isEnabled = enabledCheckBox.Checked;
+            ABIndicator.width = (int)widthTextBox.Value;
+            ABIndicator.height = (int)heightTextBox.Value;
+            switch (this.comboBox1.SelectedItem.ToString())
+            {
+                case "Top Left":
+                    ABIndicator.scrLoc = ScreenLocation.Top_Left;
+                    break;
+                case "Top Right":
+                    ABIndicator.scrLoc = ScreenLocation.Top_Right;
+                    break;
+                case "Bottom Left":
+                    ABIndicator.scrLoc = ScreenLocation.Bottom_Left;
+                    break;
+                case "Bottom Right":
+                    ABIndicator.scrLoc = ScreenLocation.Bottom_Right;
+                    break;
+            }
+            System.Xml.Serialization.XmlSerializer serializer = new System.Xml.Serialization.XmlSerializer(typeof(AfterburnerIndicator));
+            StreamWriter sw = new StreamWriter("ABWindow.xml", false, new System.Text.UTF8Encoding(false));
+            serializer.Serialize(sw, ABIndicator);
+            sw.Close();
+            this.Close();
+        }
+    }
+}

--- a/bms-burner/AfterburnerWindow.resx
+++ b/bms-burner/AfterburnerWindow.resx
@@ -1,0 +1,120 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <!-- 
+    Microsoft ResX Schema 
+    
+    Version 2.0
+    
+    The primary goals of this format is to allow a simple XML format 
+    that is mostly human readable. The generation and parsing of the 
+    various data types are done through the TypeConverter classes 
+    associated with the data types.
+    
+    Example:
+    
+    ... ado.net/XML headers & schema ...
+    <resheader name="resmimetype">text/microsoft-resx</resheader>
+    <resheader name="version">2.0</resheader>
+    <resheader name="reader">System.Resources.ResXResourceReader, System.Windows.Forms, ...</resheader>
+    <resheader name="writer">System.Resources.ResXResourceWriter, System.Windows.Forms, ...</resheader>
+    <data name="Name1"><value>this is my long string</value><comment>this is a comment</comment></data>
+    <data name="Color1" type="System.Drawing.Color, System.Drawing">Blue</data>
+    <data name="Bitmap1" mimetype="application/x-microsoft.net.object.binary.base64">
+        <value>[base64 mime encoded serialized .NET Framework object]</value>
+    </data>
+    <data name="Icon1" type="System.Drawing.Icon, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
+        <value>[base64 mime encoded string representing a byte array form of the .NET Framework object]</value>
+        <comment>This is a comment</comment>
+    </data>
+                
+    There are any number of "resheader" rows that contain simple 
+    name/value pairs.
+    
+    Each data row contains a name, and value. The row also contains a 
+    type or mimetype. Type corresponds to a .NET class that support 
+    text/value conversion through the TypeConverter architecture. 
+    Classes that don't support this are serialized and stored with the 
+    mimetype set.
+    
+    The mimetype is used for serialized objects, and tells the 
+    ResXResourceReader how to depersist the object. This is currently not 
+    extensible. For a given mimetype the value must be set accordingly:
+    
+    Note - application/x-microsoft.net.object.binary.base64 is the format 
+    that the ResXResourceWriter will generate, however the reader can 
+    read any of the formats listed below.
+    
+    mimetype: application/x-microsoft.net.object.binary.base64
+    value   : The object must be serialized with 
+            : System.Runtime.Serialization.Formatters.Binary.BinaryFormatter
+            : and then encoded with base64 encoding.
+    
+    mimetype: application/x-microsoft.net.object.soap.base64
+    value   : The object must be serialized with 
+            : System.Runtime.Serialization.Formatters.Soap.SoapFormatter
+            : and then encoded with base64 encoding.
+
+    mimetype: application/x-microsoft.net.object.bytearray.base64
+    value   : The object must be serialized into a byte array 
+            : using a System.ComponentModel.TypeConverter
+            : and then encoded with base64 encoding.
+    -->
+  <xsd:schema id="root" xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
+    <xsd:import namespace="http://www.w3.org/XML/1998/namespace" />
+    <xsd:element name="root" msdata:IsDataSet="true">
+      <xsd:complexType>
+        <xsd:choice maxOccurs="unbounded">
+          <xsd:element name="metadata">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" />
+              </xsd:sequence>
+              <xsd:attribute name="name" use="required" type="xsd:string" />
+              <xsd:attribute name="type" type="xsd:string" />
+              <xsd:attribute name="mimetype" type="xsd:string" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="assembly">
+            <xsd:complexType>
+              <xsd:attribute name="alias" type="xsd:string" />
+              <xsd:attribute name="name" type="xsd:string" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="data">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+                <xsd:element name="comment" type="xsd:string" minOccurs="0" msdata:Ordinal="2" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" msdata:Ordinal="1" />
+              <xsd:attribute name="type" type="xsd:string" msdata:Ordinal="3" />
+              <xsd:attribute name="mimetype" type="xsd:string" msdata:Ordinal="4" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="resheader">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" />
+            </xsd:complexType>
+          </xsd:element>
+        </xsd:choice>
+      </xsd:complexType>
+    </xsd:element>
+  </xsd:schema>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+</root>

--- a/bms-burner/BMSConfig.cs
+++ b/bms-burner/BMSConfig.cs
@@ -10,8 +10,8 @@ namespace bms_burner
 {
     class BMSConfig
     {
-        public int IdleDetent { get; set; }
-        public int AfterburnerDetent { get; set; }
+        public int IdleDetent { get; set; } = 0;
+        public int AfterburnerDetent { get; set; } = MainWindow.MAXIN;
         public Guid ThrottleDeviceGUID { get; set; }
         public Func<JoystickState, int> AxisDelegate { get; set; }
 
@@ -40,7 +40,9 @@ namespace bms_burner
             Guid? uid = null;
 
             deserializer = new System.Xml.Serialization.XmlSerializer(typeof(AltLauncher.JoyAssgn));
-            foreach (var deviceFile in files.Where(p => !p.EndsWith("ThrottlePosition.xml") && !p.EndsWith("MouseWheel.xml")))
+            foreach (var deviceFile in files.Where(p => !p.EndsWith("ThrottlePosition.xml") 
+                                                     && !p.EndsWith("MouseWheel.xml")
+                                                     && !p.EndsWith("AfterburnerIndicator.xml")))
             {
                 var assignments = LoadJoyAssgn(deserializer, deviceFile);
                 for (int i = 0; i < assignments.axis.Length; ++i)

--- a/bms-burner/BMSConfig.cs
+++ b/bms-burner/BMSConfig.cs
@@ -10,6 +10,22 @@ namespace bms_burner
 {
     class BMSConfig
     {
+        public static Dictionary<int, JoystickAxis> AXIS_DICT = new Dictionary<int, JoystickAxis>()
+        {
+            {0, JoystickAxis.X},
+            {0, JoystickAxis.Y},
+            {0, JoystickAxis.Z},
+            {0, JoystickAxis.Rx},
+            {0, JoystickAxis.Ry},
+            {0, JoystickAxis.Rz},
+            {0, JoystickAxis.Slider0},
+            {0, JoystickAxis.Slider1},
+        };
+        const int THR_LOC = 0x48 ; //indeex where the 16-byte throttle axis information starts at in axismapping.dat
+        const int AXIS_INFO_LENGTH = 0x10; // each axis is stored using 16 bytes of data
+        const int THR_BOUND_INDEX = 0x54; // byte which determines if throttle is bound in joystick.cal
+        const int AB_LOC_INDEX = 0x49; // byte which determines the afterburner detent position in joystick.cal
+        const int IDLE_LOC_INDEX = 0x53; //byte which determines the idle position in joystick.cal
         public int IdleDetent { get; set; } = 0;
         public int AfterburnerDetent { get; set; } = MainWindow.MAXIN;
         public Guid ThrottleDeviceGUID { get; set; }
@@ -97,6 +113,66 @@ namespace bms_burner
                 AxisDelegate = axisMapper
             };
             return config;
+        }
+
+        //TODO: look at devicesorting.txt, it might have more information on which joystick to grab
+
+        public BMSConfig ConfigFromBMS(byte[] axisMappingFile, byte[] joystickConfigFile)
+        {
+            byte[] throttleBytes = new byte[16];
+            Array.Copy(axisMappingFile, 72, throttleBytes, 0, 16);
+            int deviceNum = throttleBytes[0];
+            if (deviceNum < 2)
+                return null;
+            int index = throttleBytes[4];
+
+            Func<JoystickState, int> axisMapper = delegate (JoystickState js)
+            {
+                // From the Alt launcher:
+                // [0]=X
+                // [1]=Y
+                // [2]=Z
+                // [3]=Rx
+                // [4]=Ry
+                // [5]=Rz
+                // [6]=Slider0
+                // [7]=Slider1
+                switch (index)
+                {
+                    case 0: return js.X;
+                    case 1: return js.Y;
+                    case 2: return js.Z;
+                    case 3: return js.RotationX;
+                    case 4: return js.RotationY;
+                    case 5: return js.RotationZ;
+                    case 6: return js.Sliders[0];
+                    case 7: return js.Sliders[1];
+                    default: throw new IndexOutOfRangeException("Unknown axis index from Alt Launcher settings");
+                }
+            };
+
+            var din = new DirectInput();
+            var lst = din.GetDevices(DeviceType.Joystick, DeviceEnumerationFlags.AllDevices);
+            if (!lst.Any())
+                return null;
+            Guid uid = lst[deviceNum - 2].InstanceGuid;
+
+            const int MAXIN = 65536;
+            const int MAXOUT = 14848;
+
+            int rawABVal = joystickConfigFile[AB_LOC_INDEX];
+            int ABCutoff = MAXIN - 256 * rawABVal * MAXIN / MAXOUT;
+
+            int rawIdleVal = joystickConfigFile[IDLE_LOC_INDEX];
+            int IdleCutoff = MAXIN - 256 * rawIdleVal * MAXIN / MAXOUT;
+
+            return new BMSConfig
+            {
+                IdleDetent = IdleCutoff,
+                AfterburnerDetent = ABCutoff,
+                ThrottleDeviceGUID = uid,
+                AxisDelegate = axisMapper
+            };
         }
 
         private static AltLauncher.JoyAssgn LoadJoyAssgn(System.Xml.Serialization.XmlSerializer deserializer, string file)

--- a/bms-burner/BMSData.cs
+++ b/bms-burner/BMSData.cs
@@ -1,0 +1,95 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace bms_burner
+{
+    public struct BMSData
+    {
+
+        float x;            // Ownship North (Ft)
+        float y;            // Ownship East (Ft)
+        float z;            // Ownship Down (Ft) --- NOTE: use FlightData2 AAUZ for barometric altitude!
+        float xDot;         // Ownship North Rate (ft/sec)
+        float yDot;         // Ownship East Rate (ft/sec)
+        float zDot;         // Ownship Down Rate (ft/sec)
+        float alpha;        // Ownship AOA (Degrees)
+        float beta;         // Ownship Beta (Degrees)
+        float gamma;        // Ownship Gamma (Radians)
+        float pitch;        // Ownship Pitch (Radians)
+        float roll;         // Ownship Pitch (Radians)
+        float yaw;          // Ownship Pitch (Radians)
+        float mach;         // Ownship Mach number
+        float kias;         // Ownship Indicated Airspeed (Knots)
+        float vt;           // Ownship True Airspeed (Ft/Sec)
+        float gs;           // Ownship Normal Gs
+        float windOffset;   // Wind delta to FPM (Radians)
+        float nozzlePos;    // Ownship engine nozzle percent open (0-100)
+                            //float nozzlePos2;   // MOVED TO FlightData2! Ownship engine nozzle2 percent open (0-100) 
+        float internalFuel; // Ownship internal fuel (Lbs)
+        float externalFuel; // Ownship external fuel (Lbs)
+        float fuelFlow;     // Ownship fuel flow (Lbs/Hour)
+        float rpm;          // Ownship engine rpm (Percent 0-103)
+                            //float rpm2;         // MOVED TO FlightData2! Ownship engine rpm2 (Percent 0-103)
+        float ftit;         // Ownship Forward Turbine Inlet Temp (Degrees C)
+                            //float ftit2;        // MOVED TO FlightData2! Ownship Forward Turbine Inlet Temp2 (Degrees C)
+        float gearPos;      // Ownship Gear position 0 = up, 1 = down;
+        float speedBrake;   // Ownship speed brake position 0 = closed, 1 = 60 Degrees open
+        float epuFuel;      // Ownship EPU fuel (Percent 0-100)
+        float oilPressure;  // Ownship Oil Pressure (Percent 0-100)
+                            //float oilPressure2; // MOVED TO FlightData2! Ownship Oil Pressure2 (Percent 0-100)
+        uint lightBits;    // Cockpit Indicator Lights, one bit per bulb. See enum
+
+        // These are inputs. Use them carefully
+        // NB: these do not work when TrackIR device is enabled
+        // NB2: launch falcon with the '-head' command line parameter to activate !
+        float headPitch;    // Head pitch offset from design eye (radians)
+        float headRoll;     // Head roll offset from design eye (radians)
+        float headYaw;      // Head yaw offset from design eye (radians)
+
+        // new lights
+        uint lightBits2;   // Cockpit Indicator Lights, one bit per bulb. See enum
+        uint lightBits3;   // Cockpit Indicator Lights, one bit per bulb. See enum
+
+        // chaff/flare
+        float ChaffCount;   // Number of Chaff left
+        float FlareCount;   // Number of Flare left
+
+        // landing gear
+        float NoseGearPos;  // Position of the nose landinggear; caution: full down values defined in dat files
+        float LeftGearPos;  // Position of the left landinggear; caution: full down values defined in dat files
+        float RightGearPos; // Position of the right landinggear; caution: full down values defined in dat files
+
+        // ADI values
+        float AdiIlsHorPos; // Position of horizontal ILS bar
+        float AdiIlsVerPos; // Position of vertical ILS bar
+
+        // HSI states
+        int courseState;    // HSI_STA_CRS_STATE
+        int headingState;   // HSI_STA_HDG_STATE
+        int totalStates;    // HSI_STA_TOTAL_STATES; never set
+
+        // HSI values
+        float courseDeviation;     // HSI_VAL_CRS_DEVIATION
+        float desiredCourse;       // HSI_VAL_DESIRED_CRS
+        float distanceToBeacon;    // HSI_VAL_DISTANCE_TO_BEACON
+        float bearingToBeacon;     // HSI_VAL_BEARING_TO_BEACON
+        float currentHeading;      // HSI_VAL_CURRENT_HEADING
+        float desiredHeading;      // HSI_VAL_DESIRED_HEADING
+        float deviationLimit;      // HSI_VAL_DEV_LIMIT
+        float halfDeviationLimit;  // HSI_VAL_HALF_DEV_LIMIT
+        float localizerCourse;     // HSI_VAL_LOCALIZER_CRS
+        float airbaseX;            // HSI_VAL_AIRBASE_X
+        float airbaseY;            // HSI_VAL_AIRBASE_Y
+        float totalValues;         // HSI_VAL_TOTAL_VALUES; never set
+
+        float TrimPitch;  // Value of trim in pitch axis, -0.5 to +0.5
+        float TrimRoll;   // Value of trim in roll axis, -0.5 to +0.5
+        float TrimYaw;    // Value of trim in yaw axis, -0.5 to +0.5
+
+        // HSI flags
+        public uint hsiBits;      // HSI flags
+    }
+}

--- a/bms-burner/JoystickAxis.cs
+++ b/bms-burner/JoystickAxis.cs
@@ -1,0 +1,20 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace bms_burner
+{
+    public enum JoystickAxis
+    {
+        X,
+        Y,
+        Z,
+        Rx,
+        Ry,
+        Rz,
+        Slider0,
+        Slider1
+    }
+}

--- a/bms-burner/MainWindow.Designer.cs
+++ b/bms-burner/MainWindow.Designer.cs
@@ -40,6 +40,7 @@ namespace bms_burner
             this.grpThrottleValues = new System.Windows.Forms.GroupBox();
             this.lblAfterburner = new System.Windows.Forms.Label();
             this.picBurner = new System.Windows.Forms.PictureBox();
+            this.ABConfig = new System.Windows.Forms.Button();
             this.grpThrottleValues.SuspendLayout();
             ((System.ComponentModel.ISupportInitialize)(this.picBurner)).BeginInit();
             this.SuspendLayout();
@@ -111,7 +112,7 @@ namespace bms_burner
             this.grpThrottleValues.Controls.Add(this.lblAfterburner);
             this.grpThrottleValues.Controls.Add(this.lblThrottleReading);
             this.grpThrottleValues.Controls.Add(this.lblIdle);
-            this.grpThrottleValues.Location = new System.Drawing.Point(12, 39);
+            this.grpThrottleValues.Location = new System.Drawing.Point(12, 69);
             this.grpThrottleValues.Name = "grpThrottleValues";
             this.grpThrottleValues.Size = new System.Drawing.Size(200, 128);
             this.grpThrottleValues.TabIndex = 5;
@@ -132,17 +133,28 @@ namespace bms_burner
             // 
             this.picBurner.ErrorImage = null;
             this.picBurner.Image = global::bms_burner.Properties.Resources.Engine;
-            this.picBurner.Location = new System.Drawing.Point(219, 39);
+            this.picBurner.Location = new System.Drawing.Point(218, 69);
             this.picBurner.Name = "picBurner";
             this.picBurner.Size = new System.Drawing.Size(128, 128);
             this.picBurner.TabIndex = 6;
             this.picBurner.TabStop = false;
             // 
+            // ABConfig
+            // 
+            this.ABConfig.Location = new System.Drawing.Point(16, 40);
+            this.ABConfig.Name = "ABConfig";
+            this.ABConfig.Size = new System.Drawing.Size(163, 23);
+            this.ABConfig.TabIndex = 7;
+            this.ABConfig.Text = "Configure Afterburner Window";
+            this.ABConfig.UseVisualStyleBackColor = true;
+            this.ABConfig.Click += new System.EventHandler(this.ABConfig_Click);
+            // 
             // MainWindow
             // 
             this.AutoScaleDimensions = new System.Drawing.SizeF(6F, 13F);
             this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
-            this.ClientSize = new System.Drawing.Size(359, 180);
+            this.ClientSize = new System.Drawing.Size(359, 225);
+            this.Controls.Add(this.ABConfig);
             this.Controls.Add(this.picBurner);
             this.Controls.Add(this.btnBMSLocationBrowse);
             this.Controls.Add(this.txtBMSLocation);
@@ -171,6 +183,7 @@ namespace bms_burner
         private System.Windows.Forms.GroupBox grpThrottleValues;
         private System.Windows.Forms.Label lblAfterburner;
         private System.Windows.Forms.PictureBox picBurner;
+        private System.Windows.Forms.Button ABConfig;
     }
 }
 

--- a/bms-burner/MainWindow.cs
+++ b/bms-burner/MainWindow.cs
@@ -12,53 +12,94 @@ using System.Threading.Tasks;
 using System.Windows.Forms;
 
 using SharpDX.DirectInput;
+using Microsoft.Win32;
+using System.Runtime.InteropServices;
 
 namespace bms_burner
 {
     public partial class MainWindow : Form
     {
+        private Timer bmsPoller;
+        private bool isBMSRunning = false;
+        private const String BMS_REG_PATH = "HKEY_LOCAL_MACHINE\\SOFTWARE\\WOW6432Node\\Benchmark Sims\\Falcon BMS 4.35";
         private BMSConfig bmsConfig = null;
         private DirectInput input = new SharpDX.DirectInput.DirectInput();
         private Joystick throttle = null;
         private JoystickState throttleState = new JoystickState();
-        private const int MAXIN = 65536;
+        public const int MAXIN = 65536;
+        private const int BMS_POLLER_INTERVAL = 1000;
         private bool wasWet = false;
+        public String BMSPath;
 
         private Process player = new Process();
+        private AfterburnerIndicator ABIndicator;
 
         public MainWindow()
         {
             InitializeComponent();
+
+            bmsPoller = new Timer();
+            bmsPoller.Interval = BMS_POLLER_INTERVAL;
+            bmsPoller.Tick += bmsPoller_Tick;
+
+            BMSPath = (String)Registry.GetValue(BMS_REG_PATH, "baseDir", "");
+            this.txtBMSLocation.Text = BMSPath;
+            loadBMSConfig();
             player.StartInfo.UseShellExecute = false;
             player.StartInfo.FileName = "mpv.exe";
             player.StartInfo.Arguments = "--force-window=no ./blowers.ogg";
+
+            if (File.Exists("ABWindow.xml"))
+            {
+                var deserializer = new System.Xml.Serialization.XmlSerializer(typeof(AfterburnerIndicator));
+                var sr = new System.IO.StreamReader("ABWindow.xml", new System.Text.UTF8Encoding(false));
+                ABIndicator = (AfterburnerIndicator)deserializer.Deserialize(sr);
+            }
+            else
+            {
+                ABIndicator = new AfterburnerIndicator();
+            }
+
         }
 
         private void btnBMSLocationBrowse_Click(object sender, EventArgs e) 
         {
             if (dlgBMSLocation.ShowDialog() != DialogResult.OK) return;
-            var dirPath = Path.GetDirectoryName(dlgBMSLocation.FileName);
+            BMSPath = Path.GetDirectoryName(dlgBMSLocation.FileName);
+            txtBMSLocation.Text = BMSPath;
+            loadBMSConfig();
+        }
 
+        private void loadBMSConfig()
+        {
             try
             {
-                txtBMSLocation.Text = dirPath;
+                txtBMSLocation.Text = BMSPath;
 
-                bmsConfig = BMSConfig.FromAltLauncherConfig(dirPath + "/User/Config");
+                bmsConfig = BMSConfig.FromAltLauncherConfig(BMSPath + "/User/Config");
             }
             catch (Exception ex)
             {
-                MessageBox.Show(ex.Message, "Error reading BMS Config from " + dirPath, MessageBoxButtons.OK, MessageBoxIcon.Error);
+                MessageBox.Show(ex.Message, "Error reading BMS Config from " + BMSPath, MessageBoxButtons.OK, MessageBoxIcon.Error);
                 return;
             }
 
             lblIdle.Text = "Idle detent: " + ValueAndPercentage(bmsConfig.IdleDetent);
             lblAfterburner.Text = "AfterburnerDetent: " + ValueAndPercentage(bmsConfig.AfterburnerDetent);
 
-            throttle = new Joystick(input, bmsConfig.ThrottleDeviceGUID);
-            throttle.Acquire();
-            timer.Start();
-        }
+            try
+            {
+                throttle = new Joystick(input, bmsConfig.ThrottleDeviceGUID);
+                throttle.Acquire();
+                bmsPoller.Start();
+                timer.Start();
 
+            }
+            catch (Exception ex)
+            {
+                MessageBox.Show("No throttle found", "WARNING", MessageBoxButtons.OK);
+            }
+        }
 
         private void timer_Tick(object sender, EventArgs e)
         {
@@ -66,7 +107,9 @@ namespace bms_burner
             throttle.GetCurrentState(ref throttleState);
 
             // It's inverted, for some odd reason.
-            var current = MAXIN - throttleState.RotationZ;
+            var current = MAXIN - throttleState.X;
+
+            var current2 = MAXIN - bmsConfig.AxisDelegate(throttleState);
 
             lblThrottleReading.Text = "Throttle value: " + ValueAndPercentage(current);
 
@@ -76,7 +119,7 @@ namespace bms_burner
             if (!wasWet && isWet)
             {
                 picBurner.Image = Properties.Resources.Burner;
-                player.Start();
+                //player.Start();
             }
             else if (wasWet && !isWet)
             {
@@ -86,10 +129,45 @@ namespace bms_burner
             wasWet = isWet;
         }
 
+        private void bmsPoller_Tick(object sender, EventArgs e)
+        {
+            if (throttle == null) return;
+            if (!isBMSRunning && Process.GetProcessesByName("Falcon BMS").Length > 0)
+            {
+                isBMSRunning = true;
+                ABIndicator.Execute(bmsConfig.AxisDelegate, bmsConfig.AfterburnerDetent, throttle);
+            }
+
+            if (isBMSRunning)
+            {
+                IntPtr tmpPointer = OpenFileMapping(0x0004, false, "FalconSharedMemoryArea");
+                IntPtr mmfPointer = MapViewOfFile(tmpPointer, 0x0004, 0, 0, 0);
+                BMSData data = (BMSData)Convert.ChangeType(Marshal.PtrToStructure(mmfPointer, typeof(BMSData)), typeof(BMSData));
+                bool isBMS3d = (data.hsiBits & 0x80000000) == 0x80000000;
+                ABIndicator.onBMSPoll(isBMS3d);
+            }
+
+        }
+
         private static String ValueAndPercentage(int val)
         {
             var percent = ((double)val / (double)MAXIN) * 100;
             return String.Format("{0} ({1:D2}%)", val, (int)percent);
+        }
+
+        [DllImport("kernel32.dll", SetLastError = true)]
+        public static extern IntPtr OpenFileMapping(uint dwDesiredAccess,
+            bool bInheritHandle,
+           string lpName);
+
+        [DllImport("kernel32.dll", SetLastError = true)]
+        public static extern IntPtr MapViewOfFile(IntPtr hFileMappingObject, uint
+           dwDesiredAccess, uint dwFileOffsetHigh, uint dwFileOffsetLow,
+           uint dwNumberOfBytesToMap);
+
+        private void ABConfig_Click(object sender, EventArgs e)
+        {
+            ABIndicator = AfterburnerWindow.ShowAfterburnerWindow(ABIndicator);
         }
     }
 }

--- a/bms-burner/MainWindow.cs
+++ b/bms-burner/MainWindow.cs
@@ -107,9 +107,7 @@ namespace bms_burner
             throttle.GetCurrentState(ref throttleState);
 
             // It's inverted, for some odd reason.
-            var current = MAXIN - throttleState.X;
-
-            var current2 = MAXIN - bmsConfig.AxisDelegate(throttleState);
+            var current = MAXIN - bmsConfig.AxisDelegate(throttleState);
 
             lblThrottleReading.Text = "Throttle value: " + ValueAndPercentage(current);
 

--- a/bms-burner/ScreenLocation.cs
+++ b/bms-burner/ScreenLocation.cs
@@ -1,0 +1,16 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace bms_burner
+{
+    public enum ScreenLocation
+    {
+        Top_Left,
+        Top_Right,
+        Bottom_Left,
+        Bottom_Right,
+    }
+}

--- a/bms-burner/bms-burner.csproj
+++ b/bms-burner/bms-burner.csproj
@@ -68,9 +68,17 @@
     <Reference Include="System.Xml" />
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="AfterburnerIndicator.cs" />
+    <Compile Include="AfterburnerWindow.cs">
+      <SubType>Form</SubType>
+    </Compile>
+    <Compile Include="AfterburnerWindow.Designer.cs">
+      <DependentUpon>AfterburnerWindow.cs</DependentUpon>
+    </Compile>
     <Compile Include="AltLauncher\AxAssgn.cs" />
     <Compile Include="AltLauncher\JoyAssgn.cs" />
     <Compile Include="BMSConfig.cs" />
+    <Compile Include="BMSData.cs" />
     <Compile Include="MainWindow.cs">
       <SubType>Form</SubType>
     </Compile>
@@ -80,6 +88,10 @@
     <Compile Include="Program.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="AltLauncher\ThrottlePosition.cs" />
+    <Compile Include="ScreenLocation.cs" />
+    <EmbeddedResource Include="AfterburnerWindow.resx">
+      <DependentUpon>AfterburnerWindow.cs</DependentUpon>
+    </EmbeddedResource>
     <EmbeddedResource Include="MainWindow.resx">
       <DependentUpon>MainWindow.cs</DependentUpon>
     </EmbeddedResource>

--- a/bms-burner/bms-burner.csproj
+++ b/bms-burner/bms-burner.csproj
@@ -79,6 +79,7 @@
     <Compile Include="AltLauncher\JoyAssgn.cs" />
     <Compile Include="BMSConfig.cs" />
     <Compile Include="BMSData.cs" />
+    <Compile Include="JoystickAxis.cs" />
     <Compile Include="MainWindow.cs">
       <SubType>Form</SubType>
     </Compile>


### PR DESCRIPTION
Added a borderless window which is optionally drawn over a corner of the primary display to indicate afterburner status. It should appear only when BMS is in 3d.

Added an autodetect function for the BMS 4.35 directory.

Added BMSData, a truncated struct containing the primary shared memory data up to HsiBits.